### PR TITLE
update bzip2 to mitigate more cves

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ edition = "2021"
 [dependencies]
 aes = { version = "0.7.5", optional = true }
 byteorder = "1.4.3"
-bzip2 = { version = "0.4.3", optional = true }
+bzip2 = { version = "0.4.4", optional = true }
 constant_time_eq = { version = "0.1.5", optional = true }
 crc32fast = "1.3.2"
 flate2 = { version = "1.0.23", default-features = false, optional = true }


### PR DESCRIPTION
The 0.4.4 version resolves CVE's in the optional bzip2 dependency subtree.

This relates to #357.