### PR TITLE
Support zstd in Wasm by disabling default features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ hmac = { version = "0.12.1", optional = true, features = ["reset"] }
 pbkdf2 = {version = "0.11.0", optional = true }
 sha1 = {version = "0.10.1", optional = true }
 time = { version = "0.3.7", optional = true, default-features = false, features = ["std"] }
-zstd = { version = "0.11.2", optional = true }
+zstd = { version = "0.11.2", optional = true, default-features = false }
 
 [target.'cfg(any(all(target_arch = "arm", target_pointer_width = "32"), target_arch = "mips", target_arch = "powerpc"))'.dependencies]
 crossbeam-utils = "0.8.8"


### PR DESCRIPTION
Use case: creating zstd zips in Wasm

Currently it is not possible to create zstd zips in Wasm due to the default `zdict_builder` needing additional code that will cause compilation to fail for wasm32-unknown-unknown: https://github.com/gyscos/zstd-rs/issues/210

Since the zip crate's zstd implementation does not use anything from the `zdict_builder` feature, I've disabled it.

I've gone a step further and disabled the other features as well (`arrays` and `legacy`), as they are either unused (`arrays`) or a legacy format from 7 years ago that predates when the zip format supported zstd.

So far this patch has been working well for the Wasm application, and figured I should upstream it.