### PR TITLE
Added function to get if a file is encrypted or not

### DIFF
--- a/src/read.rs
+++ b/src/read.rs
@@ -917,6 +917,11 @@ impl<'a> ZipFile<'a> {
         self.data.compression_method
     }
 
+    /// Get if the files is encrypted or not
+    pub fn encrypted(&self) -> bool {
+        self.data.encrypted
+    }
+
     /// Get the size of the file, in bytes, in the archive
     pub fn compressed_size(&self) -> u64 {
         self.data.compressed_size


### PR DESCRIPTION
Hi,

the reason why this is useful is that file can be encrypted or not and sometime you may only want to ask for the password for files that are encrypted, but work without for non-encrypted files. Being able to know if the file is encrypted is very useful for that.