### PR TITLE
Add by_name_seek() for Stored zips

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,6 +26,7 @@
 
 pub use crate::compression::{CompressionMethod, SUPPORTED_COMPRESSION_METHODS};
 pub use crate::read::ZipArchive;
+pub use crate::read::HasZipMetadata;
 pub use crate::types::DateTime;
 pub use crate::write::ZipWriter;
 

--- a/src/read/stream.rs
+++ b/src/read/stream.rs
@@ -4,7 +4,7 @@ use std::path::Path;
 
 use super::{
     central_header_to_zip_file_inner, read_zipfile_from_stream, spec, ZipError, ZipFile,
-    ZipFileData, ZipResult,
+    ZipFileData, ZipResult, HasZipMetadata,
 };
 
 use byteorder::{LittleEndian, ReadBytesExt};

--- a/src/write.rs
+++ b/src/write.rs
@@ -1,13 +1,12 @@
 //! Types for creating ZIP archives
 
 use crate::compression::CompressionMethod;
-use crate::read::{central_header_to_zip_file, ZipArchive, ZipFile};
+use crate::read::{central_header_to_zip_file, ZipArchive, ZipFile, HasZipMetadata};
 use crate::result::{ZipError, ZipResult};
 use crate::spec;
 use crate::types::{AtomicU64, DateTime, System, ZipFileData, DEFAULT_VERSION};
 use byteorder::{LittleEndian, ReadBytesExt, WriteBytesExt};
 use crc32fast::Hasher;
-use std::convert::TryInto;
 use std::default::Default;
 use std::io;
 use std::io::prelude::*;
@@ -493,7 +492,7 @@ impl<W: Write + io::Seek> ZipWriter<W> {
     ///
     /// ```
     /// use byteorder::{LittleEndian, WriteBytesExt};
-    /// use zip::{ZipArchive, ZipWriter, result::ZipResult};
+    /// use zip::{ZipArchive, ZipWriter, result::ZipResult, HasZipMetadata};
     /// use zip::{write::FileOptions, CompressionMethod};
     /// use std::io::{Write, Cursor};
     ///


### PR DESCRIPTION
This PR adds a `ZipArchive::by_name_seek` function which returns a `ZipFileSeek` structure that implements `Seek`.
This only works for `Stored` types of zips for now, although I'm sure this can be implemented for compressed archives as well using some kind of lazy indexing structure that helps map compressed indexes to uncompressed ones quickly.

I tried various ways of adding this feature, but I could only make it work like this. I "forked" the `ZipFile` structure, added a `ZipFileSeek`, and added a common trait that implements the metadata goodies. The reason I couldn't make it work with a unified approach is because the current library supports non-`Seek` base readers, and there's no such thing as a dynamic cast in Rust (nor would I want there to be).

One consequence of the trait is that this change became **API breaking**, as the trait must be imported to access the metadata functions. I can add back the original functions that dispatches to the trait in case this is an issue.

Although I have not added tests to this crate, it has been tested fairly thoroughly with tests testing our own usage of the feature.