### PR TITLE
Update Zstd to 1.5.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ hmac = { version = "0.12.1", optional = true, features = ["reset"] }
 pbkdf2 = {version = "0.11.0", optional = true }
 sha1 = {version = "0.10.1", optional = true }
 time = { version = "0.3.7", optional = true, default-features = false, features = ["std"] }
-zstd = { version = "0.11.2", optional = true }
+zstd = { version = "0.12", optional = true }
 
 [target.'cfg(any(all(target_arch = "arm", target_pointer_width = "32"), target_arch = "mips", target_arch = "powerpc"))'.dependencies]
 crossbeam-utils = "0.8.8"


### PR DESCRIPTION
https://github.com/gyscos/zstd-rs has update a lot since 0.11.
We should flowing the source lib