### PR TITLE
use cfg-if and cfg_attr() to improve readability of feature guards

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,3 +49,7 @@ harness = false
 [[bench]]
 name = "read_metadata"
 harness = false
+
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ aes = { version = "0.8.2", optional = true }
 byteorder = "1.4.3"
 bzip2 = { version = "0.4.3", optional = true }
 constant_time_eq = { version = "0.1.5", optional = true }
+cfg-if = "1.0"
 crc32fast = "1.3.2"
 flate2 = { version = "1.0.23", default-features = false, optional = true }
 hmac = { version = "0.12.1", optional = true, features = ["reset"] }

--- a/examples/write_dir.rs
+++ b/examples/write_dir.rs
@@ -4,6 +4,7 @@ use std::iter::Iterator;
 use zip::result::ZipError;
 use zip::write::FileOptions;
 
+use cfg_if::cfg_if;
 use std::fs::File;
 use std::path::Path;
 use walkdir::{DirEntry, WalkDir};
@@ -14,28 +15,33 @@ fn main() {
 
 const METHOD_STORED: Option<zip::CompressionMethod> = Some(zip::CompressionMethod::Stored);
 
-#[cfg(any(
-    feature = "deflate",
-    feature = "deflate-miniz",
-    feature = "deflate-zlib"
-))]
-const METHOD_DEFLATED: Option<zip::CompressionMethod> = Some(zip::CompressionMethod::Deflated);
-#[cfg(not(any(
-    feature = "deflate",
-    feature = "deflate-miniz",
-    feature = "deflate-zlib"
-)))]
-const METHOD_DEFLATED: Option<zip::CompressionMethod> = None;
+cfg_if! {
+    if #[cfg(any(
+        feature = "deflate",
+        feature = "deflate-miniz",
+        feature = "deflate-zlib"
+    ))] {
+        const METHOD_DEFLATED: Option<zip::CompressionMethod> = Some(zip::CompressionMethod::Deflated);
+    } else {
+        const METHOD_DEFLATED: Option<zip::CompressionMethod> = None;
+    }
+}
 
-#[cfg(feature = "bzip2")]
-const METHOD_BZIP2: Option<zip::CompressionMethod> = Some(zip::CompressionMethod::Bzip2);
-#[cfg(not(feature = "bzip2"))]
-const METHOD_BZIP2: Option<zip::CompressionMethod> = None;
+cfg_if! {
+    if #[cfg(feature = "bzip2")] {
+        const METHOD_BZIP2: Option<zip::CompressionMethod> = Some(zip::CompressionMethod::Bzip2);
+    } else {
+        const METHOD_BZIP2: Option<zip::CompressionMethod> = None;
+    }
+}
 
-#[cfg(feature = "zstd")]
-const METHOD_ZSTD: Option<zip::CompressionMethod> = Some(zip::CompressionMethod::Zstd);
-#[cfg(not(feature = "zstd"))]
-const METHOD_ZSTD: Option<zip::CompressionMethod> = None;
+cfg_if! {
+    if #[cfg(feature = "zstd")] {
+        const METHOD_ZSTD: Option<zip::CompressionMethod> = Some(zip::CompressionMethod::Zstd);
+    } else {
+        const METHOD_ZSTD: Option<zip::CompressionMethod> = None;
+    }
+}
 
 fn real_main() -> i32 {
     let args: Vec<_> = std::env::args().collect();

--- a/src/compression.rs
+++ b/src/compression.rs
@@ -1,5 +1,6 @@
 //! Possible ZIP compression methods.
 
+use cfg_if::cfg_if;
 use std::fmt;
 
 #[allow(deprecated)]
@@ -48,41 +49,49 @@ impl CompressionMethod {
     pub const REDUCE_3: Self = CompressionMethod::Unsupported(4);
     pub const REDUCE_4: Self = CompressionMethod::Unsupported(5);
     pub const IMPLODE: Self = CompressionMethod::Unsupported(6);
-    #[cfg(any(
-        feature = "deflate",
-        feature = "deflate-miniz",
-        feature = "deflate-zlib"
-    ))]
-    pub const DEFLATE: Self = CompressionMethod::Deflated;
-    #[cfg(not(any(
-        feature = "deflate",
-        feature = "deflate-miniz",
-        feature = "deflate-zlib"
-    )))]
-    pub const DEFLATE: Self = CompressionMethod::Unsupported(8);
+    cfg_if! {
+        if #[cfg(any(
+            feature = "deflate",
+            feature = "deflate-miniz",
+            feature = "deflate-zlib"
+        ))] {
+            pub const DEFLATE: Self = CompressionMethod::Deflated;
+        } else {
+            pub const DEFLATE: Self = CompressionMethod::Unsupported(8);
+        }
+    }
     pub const DEFLATE64: Self = CompressionMethod::Unsupported(9);
     pub const PKWARE_IMPLODE: Self = CompressionMethod::Unsupported(10);
-    #[cfg(feature = "bzip2")]
-    pub const BZIP2: Self = CompressionMethod::Bzip2;
-    #[cfg(not(feature = "bzip2"))]
-    pub const BZIP2: Self = CompressionMethod::Unsupported(12);
+    cfg_if! {
+        if #[cfg(feature = "bzip2")] {
+            pub const BZIP2: Self = CompressionMethod::Bzip2;
+        } else {
+            pub const BZIP2: Self = CompressionMethod::Unsupported(12);
+        }
+    }
     pub const LZMA: Self = CompressionMethod::Unsupported(14);
     pub const IBM_ZOS_CMPSC: Self = CompressionMethod::Unsupported(16);
     pub const IBM_TERSE: Self = CompressionMethod::Unsupported(18);
     pub const ZSTD_DEPRECATED: Self = CompressionMethod::Unsupported(20);
-    #[cfg(feature = "zstd")]
-    pub const ZSTD: Self = CompressionMethod::Zstd;
-    #[cfg(not(feature = "zstd"))]
-    pub const ZSTD: Self = CompressionMethod::Unsupported(93);
+    cfg_if! {
+        if #[cfg(feature = "zstd")] {
+            pub const ZSTD: Self = CompressionMethod::Zstd;
+        } else {
+            pub const ZSTD: Self = CompressionMethod::Unsupported(93);
+        }
+    }
     pub const MP3: Self = CompressionMethod::Unsupported(94);
     pub const XZ: Self = CompressionMethod::Unsupported(95);
     pub const JPEG: Self = CompressionMethod::Unsupported(96);
     pub const WAVPACK: Self = CompressionMethod::Unsupported(97);
     pub const PPMD: Self = CompressionMethod::Unsupported(98);
-    #[cfg(feature = "aes-crypto")]
-    pub const AES: Self = CompressionMethod::Aes;
-    #[cfg(not(feature = "aes-crypto"))]
-    pub const AES: Self = CompressionMethod::Unsupported(99);
+    cfg_if! {
+        if #[cfg(feature = "aes-crypto")] {
+            pub const AES: Self = CompressionMethod::Aes;
+        } else {
+            pub const AES: Self = CompressionMethod::Unsupported(99);
+        }
+    }
 }
 impl CompressionMethod {
     /// Converts an u16 to its corresponding CompressionMethod

--- a/src/compression.rs
+++ b/src/compression.rs
@@ -22,18 +22,29 @@ pub enum CompressionMethod {
         feature = "deflate-miniz",
         feature = "deflate-zlib"
     ))]
+    #[cfg_attr(
+        docsrs,
+        doc(cfg(any(
+            feature = "deflate",
+            feature = "deflate-miniz",
+            feature = "deflate-zlib"
+        )))
+    )]
     Deflated,
     /// Compress the file using BZIP2
     #[cfg(feature = "bzip2")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "bzip2")))]
     Bzip2,
     /// Encrypted using AES.
     ///
     /// The actual compression method has to be taken from the AES extra data field
     /// or from `ZipFileData`.
     #[cfg(feature = "aes-crypto")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "aes-crypto")))]
     Aes,
     /// Compress the file using ZStandard
     #[cfg(feature = "zstd")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "zstd")))]
     Zstd,
     /// Unsupported compression method
     #[deprecated(since = "0.5.7", note = "use the constants instead")]
@@ -55,6 +66,11 @@ impl CompressionMethod {
             feature = "deflate-miniz",
             feature = "deflate-zlib"
         ))] {
+            #[cfg_attr(docsrs, doc(cfg(any(
+                feature = "deflate",
+                feature = "deflate-miniz",
+                feature = "deflate-zlib"
+            ))))]
             pub const DEFLATE: Self = CompressionMethod::Deflated;
         } else {
             pub const DEFLATE: Self = CompressionMethod::Unsupported(8);
@@ -64,6 +80,7 @@ impl CompressionMethod {
     pub const PKWARE_IMPLODE: Self = CompressionMethod::Unsupported(10);
     cfg_if! {
         if #[cfg(feature = "bzip2")] {
+            #[cfg_attr(docsrs, doc(cfg(feature = "bzip2")))]
             pub const BZIP2: Self = CompressionMethod::Bzip2;
         } else {
             pub const BZIP2: Self = CompressionMethod::Unsupported(12);
@@ -75,6 +92,7 @@ impl CompressionMethod {
     pub const ZSTD_DEPRECATED: Self = CompressionMethod::Unsupported(20);
     cfg_if! {
         if #[cfg(feature = "zstd")] {
+            #[cfg_attr(docsrs, doc(cfg(feature = "zstd")))]
             pub const ZSTD: Self = CompressionMethod::Zstd;
         } else {
             pub const ZSTD: Self = CompressionMethod::Unsupported(93);
@@ -87,6 +105,7 @@ impl CompressionMethod {
     pub const PPMD: Self = CompressionMethod::Unsupported(98);
     cfg_if! {
         if #[cfg(feature = "aes-crypto")] {
+            #[cfg_attr(docsrs, doc(cfg(feature = "aes-crypto")))]
             pub const AES: Self = CompressionMethod::Aes;
         } else {
             pub const AES: Self = CompressionMethod::Unsupported(99);
@@ -162,10 +181,18 @@ pub const SUPPORTED_COMPRESSION_METHODS: &[CompressionMethod] = &[
         feature = "deflate-miniz",
         feature = "deflate-zlib"
     ))]
+    /* NB: these don't appear to show up in the docs. */
+    #[cfg_attr(docsrs, doc(cfg(any(
+        feature = "deflate",
+        feature = "deflate-miniz",
+        feature = "deflate-zlib"
+    ))))]
     CompressionMethod::Deflated,
     #[cfg(feature = "bzip2")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "bzip2")))]
     CompressionMethod::Bzip2,
     #[cfg(feature = "zstd")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "zstd")))]
     CompressionMethod::Zstd,
 ];
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,6 +23,7 @@
 //!
 
 #![warn(missing_docs)]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 
 pub use crate::compression::{CompressionMethod, SUPPORTED_COMPRESSION_METHODS};
 pub use crate::read::ZipArchive;

--- a/src/types.rs
+++ b/src/types.rs
@@ -175,10 +175,11 @@ impl DateTime {
         }
     }
 
-    #[cfg(feature = "time")]
     /// Converts a OffsetDateTime object to a DateTime
     ///
     /// Returns `Err` when this object is out of bounds
+    #[cfg(feature = "time")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "time")))]
     #[allow(clippy::result_unit_err)]
     #[deprecated(note = "use `DateTime::try_from()`")]
     pub fn from_time(dt: OffsetDateTime) -> Result<DateTime, ()> {
@@ -195,8 +196,9 @@ impl DateTime {
         (self.day as u16) | ((self.month as u16) << 5) | ((self.year - 1980) << 9)
     }
 
-    #[cfg(feature = "time")]
     /// Converts the DateTime to a OffsetDateTime structure
+    #[cfg(feature = "time")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "time")))]
     pub fn to_time(&self) -> Result<OffsetDateTime, ComponentRange> {
         let date =
             Date::from_calendar_date(self.year as i32, Month::try_from(self.month)?, self.day)?;
@@ -256,6 +258,7 @@ impl DateTime {
 }
 
 #[cfg(feature = "time")]
+#[cfg_attr(docsrs, doc(cfg(feature = "time")))]
 impl TryFrom<OffsetDateTime> for DateTime {
     type Error = DateTimeRangeError;
 
@@ -461,6 +464,7 @@ pub enum AesMode {
 }
 
 #[cfg(feature = "aes-crypto")]
+#[cfg_attr(docsrs, doc(cfg(feature = "aes-crypto")))]
 impl AesMode {
     pub fn salt_length(&self) -> usize {
         self.key_length() / 2


### PR DESCRIPTION
1. The [`cfg-if`](https://docs.rs/cfg-if/latest/cfg_if/) crate makes it easier to read conditional compilation logic.
2. There is an undocumented hack used by many crates to get `docs.rs` builds to show whether some value is only available with a given feature enabled (see e.g. rust-random/rand#986).
    - The result can be tested with `RUSTDOCFLAGS='--cfg docsrs' cargo doc` (try opening e.g. `CompressionMethod` to see how this shows which enum cases are supported by which features).

This is not a breaking change, as `cfg-if` should generate the same code as before.