### PR TITLE
use num_enum to clean up the System type

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ aes = { version = "0.8.2", optional = true }
 byteorder = "1.4.3"
 bzip2 = { version = "0.4.3", optional = true }
 constant_time_eq = { version = "0.1.5", optional = true }
+num_enum = "0.6.1"
 crc32fast = "1.3.2"
 flate2 = { version = "1.0.23", default-features = false, optional = true }
 hmac = { version = "0.12.1", optional = true, features = ["reset"] }

--- a/src/read.rs
+++ b/src/read.rs
@@ -701,7 +701,7 @@ fn central_header_to_zip_file_inner<R: Read>(
 
     // Construct the result
     let mut result = ZipFileData {
-        system: System::from_u8((version_made_by >> 8) as u8),
+        system: System::from((version_made_by >> 8) as u8),
         version_made_by: version_made_by as u8,
         encrypted,
         using_data_descriptor,
@@ -1066,7 +1066,7 @@ pub fn read_zipfile_from_stream<'a, R: io::Read>(
     };
 
     let mut result = ZipFileData {
-        system: System::from_u8((version_made_by >> 8) as u8),
+        system: System::from((version_made_by >> 8) as u8),
         version_made_by: version_made_by as u8,
         encrypted,
         using_data_descriptor,

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,4 +1,5 @@
 //! Types that specify what is contained in a ZIP.
+use num_enum::{FromPrimitive, IntoPrimitive};
 use std::path;
 
 #[cfg(not(any(
@@ -54,23 +55,13 @@ use crate::result::DateTimeRangeError;
 #[cfg(feature = "time")]
 use time::{error::ComponentRange, Date, Month, OffsetDateTime, PrimitiveDateTime, Time};
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, FromPrimitive, IntoPrimitive)]
+#[repr(u8)]
 pub enum System {
     Dos = 0,
     Unix = 3,
+    #[num_enum(default)]
     Unknown,
-}
-
-impl System {
-    pub fn from_u8(system: u8) -> System {
-        use self::System::*;
-
-        match system {
-            0 => Dos,
-            3 => Unix,
-            _ => Unknown,
-        }
-    }
 }
 
 /// Representation of a moment in time.
@@ -477,10 +468,14 @@ mod test {
     #[test]
     fn system() {
         use super::System;
-        assert_eq!(System::Dos as u16, 0u16);
-        assert_eq!(System::Unix as u16, 3u16);
-        assert_eq!(System::from_u8(0), System::Dos);
-        assert_eq!(System::from_u8(3), System::Unix);
+        assert_eq!(u8::from(System::Dos), 0u8);
+        assert_eq!(System::Dos as u8, 0u8);
+        assert_eq!(System::Unix as u8, 3u8);
+        assert_eq!(u8::from(System::Unix), 3u8);
+        assert_eq!(System::from(0), System::Dos);
+        assert_eq!(System::from(3), System::Unix);
+        assert_eq!(u8::from(System::Unknown), 4u8);
+        assert_eq!(System::Unknown as u8, 4u8);
     }
 
     #[test]


### PR DESCRIPTION
The [`num_enum`](https://docs.rs/num_enum/latest/num_enum/) crate will automatically derive `From` implementations for `enum`s with `repr(u8)` or similar. This change removes a small amount of boilerplate.

This is not a breaking change, because `System` is not exported by this crate.