### PR TITLE
use indexmap in read::zip_archive::Shared instead of a separate vec and hashmap

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ byteorder = "1.4.3"
 bzip2 = { version = "0.4.3", optional = true }
 constant_time_eq = { version = "0.1.5", optional = true }
 crc32fast = "1.3.2"
+indexmap = "2"
 flate2 = { version = "1.0.23", default-features = false, optional = true }
 hmac = { version = "0.12.1", optional = true, features = ["reset"] }
 pbkdf2 = {version = "0.11.0", optional = true }


### PR DESCRIPTION
The [`indexmap`](https://docs.rs/indexmap/latest/indexmap/index.html) crate offers a hashmap which tracks the order each element was added. This lets us remove some boilerplate around accessing zip file entries by name or by index.

This is not a breaking change, but may improve performance and reduce memory usage.