### PR TITLE
use displaydoc and thiserror to remove some boilerplate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,8 @@ byteorder = "1.4.3"
 bzip2 = { version = "0.4.3", optional = true }
 constant_time_eq = { version = "0.1.5", optional = true }
 crc32fast = "1.3.2"
+displaydoc = "0.2.4"
+thiserror = "1.0.48"
 flate2 = { version = "1.0.23", default-features = false, optional = true }
 hmac = { version = "0.12.1", optional = true, features = ["reset"] }
 pbkdf2 = {version = "0.11.0", optional = true }

--- a/src/result.rs
+++ b/src/result.rs
@@ -1,5 +1,8 @@
 //! Error types that can be emitted from this library
 
+use displaydoc::Display;
+use thiserror::Error;
+
 use std::error::Error;
 use std::fmt;
 use std::io;
@@ -20,45 +23,19 @@ impl fmt::Display for InvalidPassword {
 impl Error for InvalidPassword {}
 
 /// Error type for Zip
-#[derive(Debug)]
+#[derive(Debug, Display, Error)]
 pub enum ZipError {
-    /// An Error caused by I/O
-    Io(io::Error),
+    /// i/o error: {0}
+    Io(#[from] io::Error),
 
-    /// This file is probably not a zip archive
+    /// invalid Zip archive: {0}
     InvalidArchive(&'static str),
 
-    /// This archive is not supported
+    /// unsupported Zip archive: {0}
     UnsupportedArchive(&'static str),
 
-    /// The requested file could not be found in the archive
+    /// specified file not found in archive
     FileNotFound,
-}
-
-impl From<io::Error> for ZipError {
-    fn from(err: io::Error) -> ZipError {
-        ZipError::Io(err)
-    }
-}
-
-impl fmt::Display for ZipError {
-    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
-        match self {
-            ZipError::Io(err) => write!(fmt, "{err}"),
-            ZipError::InvalidArchive(err) => write!(fmt, "invalid Zip archive: {err}"),
-            ZipError::UnsupportedArchive(err) => write!(fmt, "unsupported Zip archive: {err}"),
-            ZipError::FileNotFound => write!(fmt, "specified file not found in archive"),
-        }
-    }
-}
-
-impl Error for ZipError {
-    fn source(&self) -> Option<&(dyn Error + 'static)> {
-        match self {
-            ZipError::Io(err) => Some(err),
-            _ => None,
-        }
-    }
 }
 
 impl ZipError {


### PR DESCRIPTION
The [`displaydoc`](https://docs.rs/displaydoc/latest/displaydoc/) and [`thiserror`](https://docs.rs/thiserror/latest/thiserror/) crates automatically derive much of what is written in `result.rs`. This change removes some boilerplate.

This is not a breaking change, because it should generate the same code as before.