### PR TITLE
merge InvalidPassword into ZipError

### DIFF
--- a/src/read.rs
+++ b/src/read.rs
@@ -5,7 +5,7 @@ use crate::aes::{AesReader, AesReaderValid};
 use crate::compression::CompressionMethod;
 use crate::cp437::FromCp437;
 use crate::crc32::Crc32Reader;
-use crate::result::{InvalidPassword, ZipError, ZipResult};
+use crate::result::{ZipError, ZipResult};
 use crate::spec;
 use crate::types::{AesMode, AesVendorVersion, AtomicU64, DateTime, System, ZipFileData};
 use crate::zipcrypto::{ZipCryptoReader, ZipCryptoReaderValid, ZipCryptoValidator};
@@ -215,7 +215,7 @@ fn make_crypto_reader<'a>(
     password: Option<&[u8]>,
     aes_info: Option<(AesMode, AesVendorVersion)>,
     #[cfg(feature = "aes-crypto")] compressed_size: u64,
-) -> ZipResult<Result<CryptoReader<'a>, InvalidPassword>> {
+) -> ZipResult<CryptoReader<'a>> {
     #[allow(deprecated)]
     {
         if let CompressionMethod::Unsupported(_) = compression_method {
@@ -233,7 +233,7 @@ fn make_crypto_reader<'a>(
         #[cfg(feature = "aes-crypto")]
         (Some(password), Some((aes_mode, vendor_version))) => {
             match AesReader::new(reader, aes_mode, compressed_size).validate(password)? {
-                None => return Ok(Err(InvalidPassword)),
+                None => return Err(ZipError::InvalidPassword),
                 Some(r) => CryptoReader::Aes {
                     reader: r,
                     vendor_version,
@@ -247,14 +247,14 @@ fn make_crypto_reader<'a>(
                 ZipCryptoValidator::PkzipCrc32(crc32)
             };
             match ZipCryptoReader::new(reader, password).validate(validator)? {
-                None => return Ok(Err(InvalidPassword)),
+                None => return Err(ZipError::InvalidPassword),
                 Some(r) => CryptoReader::ZipCrypto(r),
             }
         }
-        (None, Some(_)) => return Ok(Err(InvalidPassword)),
+        (None, Some(_)) => return Err(ZipError::InvalidPassword),
         (None, None) => CryptoReader::Plaintext(reader),
     };
-    Ok(Ok(reader))
+    Ok(reader)
 }
 
 fn make_reader(
@@ -524,27 +524,24 @@ impl<R: Read + io::Seek> ZipArchive<R> {
         &'a mut self,
         name: &str,
         password: &[u8],
-    ) -> ZipResult<Result<ZipFile<'a>, InvalidPassword>> {
-        self.by_name_with_optional_password(name, Some(password))
+    ) -> ZipResult<ZipFile<'a>> {
+        let index = self.get_index_by_name(name)?;
+        self.unwrap_entry(index, Some(password))
     }
 
     /// Search for a file entry by name
     pub fn by_name<'a>(&'a mut self, name: &str) -> ZipResult<ZipFile<'a>> {
-        Ok(self.by_name_with_optional_password(name, None)?.unwrap())
+        let index = self.get_index_by_name(name)?;
+        self.unwrap_entry(index, None)
     }
 
-    fn by_name_with_optional_password<'a>(
-        &'a mut self,
-        name: &str,
-        password: Option<&[u8]>,
-    ) -> ZipResult<Result<ZipFile<'a>, InvalidPassword>> {
-        let index = match self.shared.names_map.get(name) {
-            Some(index) => *index,
-            None => {
-                return Err(ZipError::FileNotFound);
-            }
-        };
-        self.by_index_with_optional_password(index, password)
+    fn get_index_by_name<'a>(&'a self, name: &str) -> ZipResult<usize> {
+        let index = self
+            .shared
+            .names_map
+            .get(name)
+            .ok_or(ZipError::FileNotFound)?;
+        Ok(*index)
     }
 
     /// Get a contained file by index, decrypt with given password
@@ -564,38 +561,35 @@ impl<R: Read + io::Seek> ZipArchive<R> {
         &'a mut self,
         file_number: usize,
         password: &[u8],
-    ) -> ZipResult<Result<ZipFile<'a>, InvalidPassword>> {
-        self.by_index_with_optional_password(file_number, Some(password))
+    ) -> ZipResult<ZipFile<'a>> {
+        self.unwrap_entry(file_number, Some(password))
     }
 
     /// Get a contained file by index
     pub fn by_index(&mut self, file_number: usize) -> ZipResult<ZipFile<'_>> {
-        Ok(self
-            .by_index_with_optional_password(file_number, None)?
-            .unwrap())
+        self.unwrap_entry(file_number, None)
     }
 
     /// Get a contained file by index without decompressing it
     pub fn by_index_raw(&mut self, file_number: usize) -> ZipResult<ZipFile<'_>> {
         let reader = &mut self.reader;
-        self.shared
+        let data = self
+            .shared
             .files
             .get(file_number)
-            .ok_or(ZipError::FileNotFound)
-            .and_then(move |data| {
-                Ok(ZipFile {
-                    crypto_reader: None,
-                    reader: ZipFileReader::Raw(find_content(data, reader)?),
-                    data: Cow::Borrowed(data),
-                })
-            })
+            .ok_or(ZipError::FileNotFound)?;
+        Ok(ZipFile {
+            crypto_reader: None,
+            reader: ZipFileReader::Raw(find_content(data, reader)?),
+            data: Cow::Borrowed(data),
+        })
     }
 
-    fn by_index_with_optional_password<'a>(
+    fn unwrap_entry<'a>(
         &'a mut self,
         file_number: usize,
         mut password: Option<&[u8]>,
-    ) -> ZipResult<Result<ZipFile<'a>, InvalidPassword>> {
+    ) -> ZipResult<ZipFile<'a>> {
         let data = self
             .shared
             .files
@@ -609,7 +603,7 @@ impl<R: Read + io::Seek> ZipArchive<R> {
         }
         let limit_reader = find_content(data, &mut self.reader)?;
 
-        match make_crypto_reader(
+        let crypto_reader = make_crypto_reader(
             data.compression_method,
             data.crc32,
             data.last_modified_time,
@@ -619,15 +613,12 @@ impl<R: Read + io::Seek> ZipArchive<R> {
             data.aes_mode,
             #[cfg(feature = "aes-crypto")]
             data.compressed_size,
-        ) {
-            Ok(Ok(crypto_reader)) => Ok(Ok(ZipFile {
-                crypto_reader: Some(crypto_reader),
-                reader: ZipFileReader::NoReader,
-                data: Cow::Borrowed(data),
-            })),
-            Err(e) => Err(e),
-            Ok(Err(e)) => Ok(Err(e)),
-        }
+        )?;
+        Ok(ZipFile {
+            crypto_reader: Some(crypto_reader),
+            reader: ZipFileReader::NoReader,
+            data: Cow::Borrowed(data),
+        })
     }
 
     /// Unwrap and return the inner reader object
@@ -1119,8 +1110,7 @@ pub fn read_zipfile_from_stream<'a, R: io::Read>(
         None,
         #[cfg(feature = "aes-crypto")]
         result.compressed_size,
-    )?
-    .unwrap();
+    )?;
 
     Ok(Some(ZipFile {
         data: Cow::Owned(result),

--- a/src/result.rs
+++ b/src/result.rs
@@ -7,18 +7,6 @@ use std::io;
 /// Generic result type with ZipError as its error variant
 pub type ZipResult<T> = Result<T, ZipError>;
 
-/// The given password is wrong
-#[derive(Debug)]
-pub struct InvalidPassword;
-
-impl fmt::Display for InvalidPassword {
-    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
-        write!(fmt, "invalid password for file in archive")
-    }
-}
-
-impl Error for InvalidPassword {}
-
 /// Error type for Zip
 #[derive(Debug)]
 pub enum ZipError {
@@ -33,6 +21,11 @@ pub enum ZipError {
 
     /// The requested file could not be found in the archive
     FileNotFound,
+
+    /// Invalid password for file in archive
+    #[cfg(feature = "aes-crypto")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "aes-crypto")))]
+    InvalidPassword,
 }
 
 impl From<io::Error> for ZipError {
@@ -48,6 +41,7 @@ impl fmt::Display for ZipError {
             ZipError::InvalidArchive(err) => write!(fmt, "invalid Zip archive: {err}"),
             ZipError::UnsupportedArchive(err) => write!(fmt, "unsupported Zip archive: {err}"),
             ZipError::FileNotFound => write!(fmt, "specified file not found in archive"),
+            ZipError::InvalidPassword => write!(fmt, "Invalid password for file in archive")
         }
     }
 }
@@ -73,6 +67,8 @@ impl ZipError {
     /// }
     /// # ()
     /// ```
+    #[cfg(feature = "aes-crypto")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "aes-crypto")))]
     pub const PASSWORD_REQUIRED: &'static str = "Password required to decrypt file";
 }
 

--- a/tests/aes_encryption.rs
+++ b/tests/aes_encryption.rs
@@ -15,8 +15,7 @@ fn aes256_encrypted_uncompressed_file() {
 
     let mut file = archive
         .by_name_decrypt("secret_data_256_uncompressed", PASSWORD)
-        .expect("couldn't find file in archive")
-        .expect("invalid password");
+        .expect("couldn't find file in archive");
     assert_eq!("secret_data_256_uncompressed", file.name());
 
     let mut content = String::new();
@@ -33,8 +32,7 @@ fn aes256_encrypted_file() {
 
     let mut file = archive
         .by_name_decrypt("secret_data_256", PASSWORD)
-        .expect("couldn't find file in archive")
-        .expect("invalid password");
+        .expect("couldn't find file in archive");
     assert_eq!("secret_data_256", file.name());
 
     let mut content = String::new();
@@ -51,8 +49,7 @@ fn aes192_encrypted_file() {
 
     let mut file = archive
         .by_name_decrypt("secret_data_192", PASSWORD)
-        .expect("couldn't find file in archive")
-        .expect("invalid password");
+        .expect("couldn't find file in archive");
     assert_eq!("secret_data_192", file.name());
 
     let mut content = String::new();
@@ -69,8 +66,7 @@ fn aes128_encrypted_file() {
 
     let mut file = archive
         .by_name_decrypt("secret_data_128", PASSWORD)
-        .expect("couldn't find file in archive")
-        .expect("invalid password");
+        .expect("couldn't find file in archive");
     assert_eq!("secret_data_128", file.name());
 
     let mut content = String::new();


### PR DESCRIPTION
A lot of the logic in `read.rs` goes through functions that return a nested `Result<Result<...>, InvalidPassword>`, which seems unnecessary when we don't even have password support at all in some configurations. This change makes `InvalidPassword` into a case of `ZipError` and avoids needing to separately unwrap an `InvalidPassword` error.

**This is a breaking change, because it modifies `zip::result::ZipError` and removes `zip::result::InvalidPassword`.**