### PR TITLE
provide error cases for DateTime parsing

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,8 @@ byteorder = "1.4.3"
 bzip2 = { version = "0.4.3", optional = true }
 constant_time_eq = { version = "0.1.5", optional = true }
 crc32fast = "1.3.2"
+displaydoc = "0.2.4"
+thiserror = "1.0.48"
 flate2 = { version = "1.0.23", default-features = false, optional = true }
 hmac = { version = "0.12.1", optional = true, features = ["reset"] }
 pbkdf2 = {version = "0.11.0", optional = true }

--- a/src/result.rs
+++ b/src/result.rs
@@ -1,8 +1,13 @@
 //! Error types that can be emitted from this library
 
+use displaydoc::Display;
+use thiserror::Error;
+
 use std::error::Error;
 use std::fmt;
 use std::io;
+use std::num::TryFromIntError;
+use std::ops::{Range, RangeInclusive};
 
 /// Generic result type with ZipError as its error variant
 pub type ZipResult<T> = Result<T, ZipError>;
@@ -83,16 +88,20 @@ impl From<ZipError> for io::Error {
 }
 
 /// Error type for time parsing
-#[derive(Debug)]
-pub struct DateTimeRangeError;
-
-impl fmt::Display for DateTimeRangeError {
-    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
-        write!(
-            fmt,
-            "a date could not be represented within the bounds the MS-DOS date range (1980-2107)"
-        )
-    }
+#[derive(Debug, Display, Error)]
+pub enum DateTimeRangeError {
+    /// year {0} was not in range {1:?}
+    InvalidYear(u16, RangeInclusive<u16>),
+    /// month {0} was not in range {1:?}
+    InvalidMonth(u8, RangeInclusive<u8>),
+    /// day {0} was not in range {1:?}
+    InvalidDay(u8, RangeInclusive<u8>),
+    /// hour {0} was not in range {1:?}
+    InvalidHour(u8, Range<u8>),
+    /// minute {0} was not in range {1:?}
+    InvalidMinute(u8, Range<u8>),
+    /// second {0} was not in range {1:?}
+    InvalidSecond(u8, RangeInclusive<u8>),
+    /// failed to convert {0}: {1}
+    NumericConversion(&'static str, #[source] TryFromIntError),
 }
-
-impl Error for DateTimeRangeError {}

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,4 +1,6 @@
 //! Types that specify what is contained in a ZIP.
+use std::convert::TryInto;
+use std::ops::{Range, RangeInclusive};
 use std::path;
 
 #[cfg(not(any(
@@ -52,7 +54,9 @@ mod atomic {
 #[cfg(feature = "time")]
 use crate::result::DateTimeRangeError;
 #[cfg(feature = "time")]
-use time::{error::ComponentRange, Date, Month, OffsetDateTime, PrimitiveDateTime, Time};
+use time::{
+    error::ComponentRange, Date, Month, OffsetDateTime, PrimitiveDateTime, Time, UtcOffset,
+};
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum System {
@@ -101,9 +105,15 @@ pub struct DateTime {
 }
 
 impl ::std::default::Default for DateTime {
-    /// Constructs an 'default' datetime of 1980-01-01 00:00:00
     fn default() -> DateTime {
-        DateTime {
+        Self::zero()
+    }
+}
+
+impl DateTime {
+    /// Constructs a 'default' datetime of 1980-01-01 00:00:00
+    pub const fn zero() -> Self {
+        Self {
             year: 1980,
             month: 1,
             day: 1,
@@ -112,9 +122,74 @@ impl ::std::default::Default for DateTime {
             second: 0,
         }
     }
-}
 
-impl DateTime {
+    /// The allowed range for years in a zip file's timestamp.
+    pub const YEAR_RANGE: RangeInclusive<u16> = 1980..=2107;
+    /// The allowed range for months in a zip file's timestamp.
+    pub const MONTH_RANGE: RangeInclusive<u8> = 1..=12;
+    /// The allowed range for days in a zip file's timestamp.
+    pub const DAY_RANGE: RangeInclusive<u8> = 1..=31;
+    /// The allowed range for hours in a zip file's timestamp.
+    pub const HOUR_RANGE: Range<u8> = 0..24;
+    /// The allowed range for minutes in a zip file's timestamp.
+    pub const MINUTE_RANGE: Range<u8> = 0..60;
+    /// The allowed range for seconds in a zip file's timestamp.
+    pub const SECOND_RANGE: RangeInclusive<u8> = 0..=60;
+
+    fn check_year(year: u16) -> Result<(), DateTimeRangeError> {
+        if Self::YEAR_RANGE.contains(&year) {
+            Ok(())
+        } else {
+            Err(DateTimeRangeError::InvalidYear(year, Self::YEAR_RANGE))
+        }
+    }
+
+    fn check_month(month: u8) -> Result<(), DateTimeRangeError> {
+        if Self::MONTH_RANGE.contains(&month) {
+            Ok(())
+        } else {
+            Err(DateTimeRangeError::InvalidMonth(month, Self::MONTH_RANGE))
+        }
+    }
+
+    fn check_day(day: u8) -> Result<(), DateTimeRangeError> {
+        if Self::DAY_RANGE.contains(&day) {
+            Ok(())
+        } else {
+            Err(DateTimeRangeError::InvalidDay(day, Self::DAY_RANGE))
+        }
+    }
+
+    fn check_hour(hour: u8) -> Result<(), DateTimeRangeError> {
+        if Self::HOUR_RANGE.contains(&hour) {
+            Ok(())
+        } else {
+            Err(DateTimeRangeError::InvalidHour(hour, Self::HOUR_RANGE))
+        }
+    }
+
+    fn check_minute(minute: u8) -> Result<(), DateTimeRangeError> {
+        if Self::MINUTE_RANGE.contains(&minute) {
+            Ok(())
+        } else {
+            Err(DateTimeRangeError::InvalidMinute(
+                minute,
+                Self::MINUTE_RANGE,
+            ))
+        }
+    }
+
+    fn check_second(second: u8) -> Result<(), DateTimeRangeError> {
+        if Self::SECOND_RANGE.contains(&second) {
+            Ok(())
+        } else {
+            Err(DateTimeRangeError::InvalidSecond(
+                second,
+                Self::SECOND_RANGE,
+            ))
+        }
+    }
+
     /// Converts an msdos (u16, u16) pair to a DateTime object
     pub fn from_msdos(datepart: u16, timepart: u16) -> DateTime {
         let seconds = (timepart & 0b0000000000011111) << 1;
@@ -143,7 +218,6 @@ impl DateTime {
     /// * hour: [0, 23]
     /// * minute: [0, 59]
     /// * second: [0, 60]
-    #[allow(clippy::result_unit_err)]
     pub fn from_date_and_time(
         year: u16,
         month: u8,
@@ -151,32 +225,29 @@ impl DateTime {
         hour: u8,
         minute: u8,
         second: u8,
-    ) -> Result<DateTime, ()> {
-        if (1980..=2107).contains(&year)
-            && (1..=12).contains(&month)
-            && (1..=31).contains(&day)
-            && hour <= 23
-            && minute <= 59
-            && second <= 60
-        {
-            Ok(DateTime {
-                year,
-                month,
-                day,
-                hour,
-                minute,
-                second,
-            })
-        } else {
-            Err(())
-        }
+    ) -> Result<DateTime, DateTimeRangeError> {
+        Self::check_year(year)?;
+        Self::check_month(month)?;
+        Self::check_day(day)?;
+        Self::check_hour(hour)?;
+        Self::check_minute(minute)?;
+        Self::check_second(second)?;
+        Ok(Self {
+            year,
+            month,
+            day,
+            hour,
+            minute,
+            second,
+        })
     }
 
-    #[cfg(feature = "time")]
     /// Converts a OffsetDateTime object to a DateTime
     ///
     /// Returns `Err` when this object is out of bounds
     #[allow(clippy::result_unit_err)]
+    #[cfg(feature = "time")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "time")))]
     #[deprecated(note = "use `DateTime::try_from()`")]
     pub fn from_time(dt: OffsetDateTime) -> Result<DateTime, ()> {
         dt.try_into().map_err(|_err| ())
@@ -192,13 +263,22 @@ impl DateTime {
         (self.day as u16) | ((self.month as u16) << 5) | ((self.year - 1980) << 9)
     }
 
-    #[cfg(feature = "time")]
     /// Converts the DateTime to a OffsetDateTime structure
+    #[cfg(feature = "time")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "time")))]
+    #[deprecated(note = "use `DateTime::to_time_with_offset()`")]
     pub fn to_time(&self) -> Result<OffsetDateTime, ComponentRange> {
+        self.to_time_with_offset(UtcOffset::UTC)
+    }
+
+    /// Converts the DateTime to a OffsetDateTime structure, given a UTC offset.
+    #[cfg(feature = "time")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "time")))]
+    pub fn to_time_with_offset(&self, offset: UtcOffset) -> Result<OffsetDateTime, ComponentRange> {
         let date =
             Date::from_calendar_date(self.year as i32, Month::try_from(self.month)?, self.day)?;
         let time = Time::from_hms(self.hour, self.minute, self.second)?;
-        Ok(PrimitiveDateTime::new(date, time).assume_utc())
+        Ok(PrimitiveDateTime::new(date, time).assume_offset(offset))
     }
 
     /// Get the year. There is no epoch, i.e. 2018 will be returned as 2018.
@@ -257,18 +337,17 @@ impl TryFrom<OffsetDateTime> for DateTime {
     type Error = DateTimeRangeError;
 
     fn try_from(dt: OffsetDateTime) -> Result<Self, Self::Error> {
-        if dt.year() >= 1980 && dt.year() <= 2107 {
-            Ok(DateTime {
-                year: (dt.year()) as u16,
-                month: (dt.month()) as u8,
-                day: dt.day(),
-                hour: dt.hour(),
-                minute: dt.minute(),
-                second: dt.second(),
-            })
-        } else {
-            Err(DateTimeRangeError)
-        }
+        let year: u16 = dt
+            .year()
+            .try_into()
+            .map_err(|e| DateTimeRangeError::NumericConversion("year", e))?;
+        let month: u8 = dt.month().into();
+        let day: u8 = dt.day().into();
+        let hour: u8 = dt.hour().into();
+        let minute: u8 = dt.minute().into();
+        let second: u8 = dt.second().into();
+
+        Self::from_date_and_time(year, month, day, hour, minute, second)
     }
 }
 
@@ -553,7 +632,7 @@ mod test {
     }
 
     #[cfg(feature = "time")]
-    use time::{format_description::well_known::Rfc3339, OffsetDateTime};
+    use time::{format_description::well_known::Rfc3339, OffsetDateTime, UtcOffset};
 
     #[cfg(feature = "time")]
     #[test]
@@ -588,10 +667,14 @@ mod test {
         assert_eq!(dt.second(), 30);
 
         #[cfg(feature = "time")]
-        assert_eq!(
-            dt.to_time().unwrap().format(&Rfc3339).unwrap(),
-            "2018-11-17T10:38:30Z"
-        );
+        {
+            let offset_time = dt.to_time_with_offset(UtcOffset::UTC).unwrap();
+            assert_eq!(dt.to_time().unwrap(), offset_time);
+            assert_eq!(
+                offset_time.format(&Rfc3339).unwrap(),
+                "2018-11-17T10:38:30Z"
+            );
+        }
     }
 
     #[test]
@@ -606,7 +689,10 @@ mod test {
         assert_eq!(dt.second(), 62);
 
         #[cfg(feature = "time")]
-        assert!(dt.to_time().is_err());
+        {
+            assert!(dt.to_time().is_err());
+            assert!(dt.to_time_with_offset(UtcOffset::UTC).is_err());
+        }
 
         let dt = DateTime::from_msdos(0x0000, 0x0000);
         assert_eq!(dt.year(), 1980);
@@ -617,7 +703,10 @@ mod test {
         assert_eq!(dt.second(), 0);
 
         #[cfg(feature = "time")]
-        assert!(dt.to_time().is_err());
+        {
+            assert!(dt.to_time().is_err());
+            assert!(dt.to_time_with_offset(UtcOffset::UTC).is_err());
+        }
     }
 
     #[cfg(feature = "time")]

--- a/src/types.rs
+++ b/src/types.rs
@@ -218,7 +218,39 @@ impl DateTime {
     /// * hour: [0, 23]
     /// * minute: [0, 59]
     /// * second: [0, 60]
+    #[allow(clippy::result_unit_err)]
+    #[deprecated(note = "use DateTime::parse_from_date_and_time() instead")]
     pub fn from_date_and_time(
+        year: u16,
+        month: u8,
+        day: u8,
+        hour: u8,
+        minute: u8,
+        second: u8,
+    ) -> Result<DateTime, ()> {
+        Self::parse_from_date_and_time(year, month, day, hour, minute, second).map_err(|_| ())
+    }
+
+    /// Constructs a DateTime from a specific date and time
+    ///
+    /// The bounds are:
+    /// * year ([`Self::YEAR_RANGE`]): [1980, 2107]
+    /// * month ([`Self::MONTH_RANGE`]): [1, 12]
+    /// * day ([`Self::DAY_RANGE`]): [1, 31]
+    /// * hour ([`Self::HOUR_RANGE`]): [0, 23]
+    /// * minute ([`Self::MINUTE_RANGE`]): [0, 59]
+    /// * second ([`Self::SECOND_RANGE`]): [0, 60]
+    ///
+    ///```
+    /// use zip::{DateTime, result::DateTimeRangeError};
+    ///
+    /// assert!(DateTime::parse_from_date_and_time(1980, 1, 1, 0, 0, 0).is_ok());
+    /// assert!(matches![
+    ///   DateTime::parse_from_date_and_time(1979, 1, 1, 0, 0, 0),
+    ///   Err(DateTimeRangeError::InvalidYear(1979, _)),
+    /// ]);
+    ///```
+    pub fn parse_from_date_and_time(
         year: u16,
         month: u8,
         day: u8,
@@ -347,7 +379,7 @@ impl TryFrom<OffsetDateTime> for DateTime {
         let minute: u8 = dt.minute().into();
         let second: u8 = dt.second().into();
 
-        Self::from_date_and_time(year, month, day, hour, minute, second)
+        Self::parse_from_date_and_time(year, month, day, hour, minute, second)
     }
 }
 


### PR DESCRIPTION
1. Currently, there is no indication of why a `DateTime` construction failed. Since zip files have a strange representation for dates and times, it's helpful to specify why something failed.
    - This change adds multiple cases to an enum `DateTimeRangeError`.
    - This change deprecates `DateTime::from_date_and_time()`, which ignores `DateTimeRangeError`, and adds `DateTime::parse_from_date_and_time()`, which retains the error case.
2. The `DateTime::to_time()` method currently assumes the desired UTC offset is GMT+-0 (GMT). We would like to make this configurable, so that if a zip file was created by a machine with a different UTC offset, we can invert that when reading the zip file.
    - This change deprecates `DateTime::to_time()` and adds `DateTime::to_time_with_offset()`.
3. It's not obvious what value is returned by `DateTime::default()`.
    - This change adds a new `const` method `DateTime::zero()` to make the use of the minimum possible date/time explicit.

This is not a breaking change, since `DateTimeRangeError` was previously an empty struct, and no method signatures are changed.