### PR TITLE
add ZipWriter::finish_into_readable()

### DIFF
--- a/src/write.rs
+++ b/src/write.rs
@@ -318,6 +318,38 @@ impl<A: Read + Write + io::Seek> ZipWriter<A> {
             writing_raw: true, // avoid recomputing the last file's header
         })
     }
+
+    /// Write the zip file into the backing stream, then produce a readable archive of that data.
+    ///
+    /// This method avoids parsing the central directory records at the end of the stream for
+    /// a slight performance improvement over running [`ZipArchive::new()`] on the output of
+    /// [`Self::finish()`].
+    ///
+    ///```
+    /// # fn main() -> Result<(), zip::result::ZipError> {
+    /// use std::io::{Cursor, prelude::*};
+    /// use zip::{ZipArchive, ZipWriter, write::FileOptions};
+    ///
+    /// let buf = Cursor::new(Vec::new());
+    /// let mut zip = ZipWriter::new(buf);
+    /// let options = FileOptions::default();
+    /// zip.start_file("a.txt", options)?;
+    /// zip.write_all(b"hello\n")?;
+    ///
+    /// let mut zip = zip.finish_into_readable()?;
+    /// let mut s: String = String::new();
+    /// zip.by_name("a.txt")?.read_to_string(&mut s)?;
+    /// assert_eq!(s, "hello\n");
+    /// # Ok(())
+    /// # }
+    ///```
+    pub fn finish_into_readable(mut self) -> ZipResult<ZipArchive<A>> {
+        let inner = self.finish()?;
+        let comment = mem::take(&mut self.comment);
+        let files = mem::take(&mut self.files);
+        let archive = ZipArchive::from_finalized_writer(files, comment, inner)?;
+        Ok(archive)
+    }
 }
 
 impl<W: Write + io::Seek> ZipWriter<W> {


### PR DESCRIPTION
In my project [`medusa-zip`](https://github.com/cosmicexplorer/medusa-zip/), I often write to a zip file and then immediately read it back. Writing a zip file somewhere and then providing a `ZipArchive` view over its contents seems like a reasonable enough use case to support upstream.

This is not a breaking change.