### PR TITLE
Bump constant_time_eq to 0.3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,13 +9,13 @@ description = """
 Library to support the reading and writing of zip files.
 """
 edition = "2021"
-rust-version = "1.59.0"
+rust-version = "1.66.0"
 
 [dependencies]
 aes = { version = "0.8.2", optional = true }
 byteorder = "1.4.3"
 bzip2 = { version = "0.4.3", optional = true }
-constant_time_eq = { version = "0.1.5", optional = true }
+constant_time_eq = { version = "0.3", optional = true }
 crc32fast = "1.3.2"
 flate2 = { version = "1.0.23", default-features = false, optional = true }
 hmac = { version = "0.12.1", optional = true, features = ["reset"] }


### PR DESCRIPTION
0.3.0 is the latest release. The primary motivator for this change is to eliminate the CC0 license from the dependency tree, which was fixed in constant_time_eq 0.2.4:

  https://github.com/cesarb/constant_time_eq/commit/0738c1a579343d31406d59ed9354f2f92e896bce

This change also raises the minimum supported Rust version to 1.66 since that is the MSRV for constant_time_eq.