### PR TITLE
parameterize ZipFile by stream type and remove the lifetime so it can be Send + 'static

### DIFF
--- a/src/aes.rs
+++ b/src/aes.rs
@@ -113,7 +113,7 @@ impl<R: Read> AesReader<R> {
 /// There is a 1 in 65536 chance that an invalid password passes that check.
 /// After the data has been read and decrypted an HMAC will be checked and provide a final means
 /// to check if either the password is invalid or if the data has been changed.
-pub struct AesReaderValid<R: Read> {
+pub struct AesReaderValid<R> {
     reader: R,
     data_remaining: u64,
     cipher: Box<dyn aes_ctr::AesCipher>,
@@ -177,7 +177,7 @@ impl<R: Read> Read for AesReaderValid<R> {
     }
 }
 
-impl<R: Read> AesReaderValid<R> {
+impl<R> AesReaderValid<R> {
     /// Consumes this decoder, returning the underlying reader.
     pub fn into_inner(self) -> R {
         self.reader

--- a/src/write.rs
+++ b/src/write.rs
@@ -410,8 +410,12 @@ impl<W: Write + io::Seek> ZipWriter<W> {
             self.files.push(file);
         }
         if let Some(keys) = options.encrypt_with {
-            let mut zipwriter = crate::zipcrypto::ZipCryptoWriter { writer: core::mem::replace(&mut self.inner, GenericZipWriter::Closed).unwrap(), buffer: vec![], keys };
-            let mut crypto_header = [0u8; 12];
+            let mut zipwriter = crate::zipcrypto::ZipCryptoWriter {
+                writer: core::mem::replace(&mut self.inner, GenericZipWriter::Closed).unwrap(),
+                buffer: vec![],
+                keys,
+            };
+            let crypto_header = [0u8; 12];
 
             zipwriter.write_all(&crypto_header)?;
             self.inner = GenericZipWriter::Storer(MaybeEncrypted::Encrypted(zipwriter));
@@ -428,10 +432,11 @@ impl<W: Write + io::Seek> ZipWriter<W> {
         match core::mem::replace(&mut self.inner, GenericZipWriter::Closed) {
             GenericZipWriter::Storer(MaybeEncrypted::Encrypted(writer)) => {
                 let crc32 = self.stats.hasher.clone().finalize();
-                self.inner = GenericZipWriter::Storer(MaybeEncrypted::Unencrypted(writer.finish(crc32)?))
+                self.inner =
+                    GenericZipWriter::Storer(MaybeEncrypted::Unencrypted(writer.finish(crc32)?))
             }
             GenericZipWriter::Storer(w) => self.inner = GenericZipWriter::Storer(w),
-            _ => unreachable!()
+            _ => unreachable!(),
         }
         let writer = self.inner.get_plain();
 
@@ -680,9 +685,10 @@ impl<W: Write + io::Seek> ZipWriter<W> {
     ///     Ok(())
     /// }
     /// ```
-    pub fn raw_copy_file_rename<S>(&mut self, mut file: ZipFile, name: S) -> ZipResult<()>
+    pub fn raw_copy_file_rename<S, R>(&mut self, mut file: ZipFile<R>, name: S) -> ZipResult<()>
     where
         S: Into<String>,
+        R: Read,
     {
         let mut options = FileOptions::default()
             .large_file(file.compressed_size().max(file.size()) > spec::ZIP64_BYTES_THR)
@@ -730,7 +736,7 @@ impl<W: Write + io::Seek> ZipWriter<W> {
     ///     Ok(())
     /// }
     /// ```
-    pub fn raw_copy_file(&mut self, file: ZipFile) -> ZipResult<()> {
+    pub fn raw_copy_file<R: Read>(&mut self, file: ZipFile<R>) -> ZipResult<()> {
         let name = file.name().to_owned();
         self.raw_copy_file_rename(file, name)
     }

--- a/src/zipcrypto.rs
+++ b/src/zipcrypto.rs
@@ -167,7 +167,7 @@ impl<R: std::io::Read> std::io::Read for ZipCryptoReaderValid<R> {
     }
 }
 
-impl<R: std::io::Read> ZipCryptoReaderValid<R> {
+impl<R> ZipCryptoReaderValid<R> {
     /// Consumes this decoder, returning the underlying reader.
     pub fn into_inner(self) -> R {
         self.reader.file


### PR DESCRIPTION
It's currently difficult to use this crate in `async` Rust code. One reason for that is the requirement that all captured variables in closures for most async executors must be `Send + 'static`, neither of which is true for `ZipFile<'a>` right now, requiring `unsafe` workarounds for the lifetime rules (e.g. casting a pointer to a usize, as in https://github.com/cosmicexplorer/symbolic-fs/blob/827a71e72cd7e3f5b7fd3fe2a0f3ad836508eff6/handles/src/lib.rs#L479).

This change does two things:
1. Parameterize `ZipFile<S>` by the type of the inner readable stream `S`, and remove the lifetime requirement.
2. Roll our own `Limiter<S>` to perform the role of `io::Take<&mut dyn R>`.

This is unfortunately a breaking change because `ZipFile` is a public API.