### PR TITLE
chore: bump constant_time_eq to 0.2.6

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ rust-version = "1.59.0"
 aes = { version = "0.8.2", optional = true }
 byteorder = "1.4.3"
 bzip2 = { version = "0.4.3", optional = true }
-constant_time_eq = { version = "0.1.5", optional = true }
+constant_time_eq = { version = "0.2.6", optional = true }
 crc32fast = "1.3.2"
 flate2 = { version = "1.0.23", default-features = false, optional = true }
 hmac = { version = "0.12.1", optional = true, features = ["reset"] }


### PR DESCRIPTION
This should be a pretty straightforward bump, and it should not involve any breaking change.

The reason behind this bump is that `constant_time_eq` has a less strict license since version 0.2.4. However, it is not possible to bump to 0.3 because the MSRV for that is 1.66, on the other hand 0.2.6 uses 1.59 as MSRV.

Keep in mind, however, that `zip` cannot  be compiled anymore with Rust 1.59 (I suppose you are aware of that), therefore I am not able to demonstrate what I am saying, I base my assumptions on the changelog of `constant_time_eq`.