### PR TITLE
Fix directory check in extract function on Windows

### DIFF
--- a/src/read.rs
+++ b/src/read.rs
@@ -456,7 +456,7 @@ impl<R: Read + io::Seek> ZipArchive<R> {
 
             let outpath = directory.as_ref().join(filepath);
 
-            if file.name().ends_with('/') {
+            if file.is_dir() {
                 fs::create_dir_all(&outpath)?;
             } else {
                 if let Some(p) = outpath.parent() {

--- a/src/read/stream.rs
+++ b/src/read/stream.rs
@@ -67,7 +67,7 @@ impl<R: Read> ZipStreamReader<R> {
 
                 let outpath = self.0.join(filepath);
 
-                if file.name().ends_with('/') {
+                if file.is_dir() {
                     fs::create_dir_all(&outpath)?;
                 } else {
                     if let Some(p) = outpath.parent() {


### PR DESCRIPTION
The directory check inside the extract function fails if the path uses the Windows style path separator and not the Unix style. A function "is_dir" already exists and accounts for this so this change switches to using that function instead.