### PR TITLE
Use clap to parse args and add compression method argument in write_dir example

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,6 @@ rust-version = "1.59.0"
 aes = { version = "0.8.2", optional = true }
 byteorder = "1.4.3"
 bzip2 = { version = "0.4.3", optional = true }
-clap = { version = "4.4.11", features = ["derive"] }
 constant_time_eq = { version = "0.1.5", optional = true }
 crc32fast = "1.3.2"
 flate2 = { version = "1.0.23", default-features = false, optional = true }
@@ -33,6 +32,7 @@ bencher = "0.1.5"
 getrandom = "0.2.5"
 walkdir = "2.3.2"
 time = { version = "0.3.7", features = ["formatting", "macros"] }
+clap = { version = "4.4.14", features = ["derive"] }
 
 [features]
 aes-crypto = [ "aes", "constant_time_eq", "hmac", "pbkdf2", "sha1" ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ rust-version = "1.59.0"
 aes = { version = "0.8.2", optional = true }
 byteorder = "1.4.3"
 bzip2 = { version = "0.4.3", optional = true }
+clap = { version = "4.4.11", features = ["derive"] }
 constant_time_eq = { version = "0.1.5", optional = true }
 crc32fast = "1.3.2"
 flate2 = { version = "1.0.23", default-features = false, optional = true }

--- a/examples/write_dir.rs
+++ b/examples/write_dir.rs
@@ -6,7 +6,7 @@ use zip::result::ZipError;
 use zip::write::FileOptions;
 
 use std::fs::File;
-use std::path::{PathBuf, Path};
+use std::path::{Path, PathBuf};
 use walkdir::{DirEntry, WalkDir};
 
 #[derive(Parser)]

--- a/examples/write_dir.rs
+++ b/examples/write_dir.rs
@@ -23,12 +23,12 @@ struct Args {
 
 #[derive(Clone, ValueEnum)]
 enum CompressionMethod {
-    MethodStored,
-    MethodDeflated,
-    MethodDeflatedMiniz,
-    MethodDeflatedZlib,
-    MethodBzip2,
-    MethodZstd,
+    Stored,
+    Deflated,
+    DeflatedMiniz,
+    DeflatedZlib,
+    Bzip2,
+    Zstd,
 }
 
 fn main() {
@@ -40,8 +40,8 @@ fn real_main() -> i32 {
     let src_dir = &args.source;
     let dst_file = &args.destination;
     let method = match args.compression_method {
-        CompressionMethod::MethodStored => zip::CompressionMethod::Stored,
-        CompressionMethod::MethodDeflated => {
+        CompressionMethod::Stored => zip::CompressionMethod::Stored,
+        CompressionMethod::Deflated => {
             #[cfg(not(feature = "deflate"))]
             {
                 println!("The `deflate` feature is not enabled");
@@ -50,7 +50,7 @@ fn real_main() -> i32 {
             #[cfg(feature = "deflate")]
             zip::CompressionMethod::Deflated
         },
-        CompressionMethod::MethodDeflatedMiniz => {
+        CompressionMethod::DeflatedMiniz => {
             #[cfg(not(feature = "deflate-miniz"))]
             {
                 println!("The `deflate-miniz` feature is not enabled");
@@ -59,7 +59,7 @@ fn real_main() -> i32 {
             #[cfg(feature = "deflate-miniz")]
             zip::CompressionMethod::Deflated
         },
-        CompressionMethod::MethodDeflatedZlib => {
+        CompressionMethod::DeflatedZlib => {
             #[cfg(not(feature = "deflate-zlib"))]
             {
                 println!("The `deflate-zlib` feature is not enabled");
@@ -68,7 +68,7 @@ fn real_main() -> i32 {
             #[cfg(feature = "deflate-zlib")]
             zip::CompressionMethod::Deflated
         },
-        CompressionMethod::MethodBzip2 => {
+        CompressionMethod::Bzip2 => {
             #[cfg(not(feature = "bzip2"))]
             {
                 println!("The `bzip2` feature is not enabled");
@@ -77,7 +77,7 @@ fn real_main() -> i32 {
             #[cfg(feature = "bzip2")]
             zip::CompressionMethod::Bzip2
         },
-        CompressionMethod::MethodZstd => {
+        CompressionMethod::Zstd => {
             #[cfg(not(feature = "zstd"))]
             {
                 println!("The `zstd` feature is not enabled");

--- a/examples/write_dir.rs
+++ b/examples/write_dir.rs
@@ -35,91 +35,62 @@ fn main() {
     std::process::exit(real_main());
 }
 
-const METHOD_STORED: Option<zip::CompressionMethod> = Some(zip::CompressionMethod::Stored);
-
-#[cfg(any(
-    feature = "deflate",
-    feature = "deflate-miniz",
-    feature = "deflate-zlib"
-))]
-const METHOD_DEFLATED: Option<zip::CompressionMethod> = Some(zip::CompressionMethod::Deflated);
-#[cfg(not(any(
-    feature = "deflate",
-    feature = "deflate-miniz",
-    feature = "deflate-zlib"
-)))]
-const METHOD_DEFLATED: Option<zip::CompressionMethod> = None;
-
-#[cfg(feature = "bzip2")]
-const METHOD_BZIP2: Option<zip::CompressionMethod> = Some(zip::CompressionMethod::Bzip2);
-#[cfg(not(feature = "bzip2"))]
-const METHOD_BZIP2: Option<zip::CompressionMethod> = None;
-
-#[cfg(feature = "zstd")]
-const METHOD_ZSTD: Option<zip::CompressionMethod> = Some(zip::CompressionMethod::Zstd);
-#[cfg(not(feature = "zstd"))]
-const METHOD_ZSTD: Option<zip::CompressionMethod> = None;
-
 fn real_main() -> i32 {
-    // let args: Vec<_> = std::env::args().collect();
-    // if args.len() < 3 {
-    //     println!(
-    //         "Usage: {} <source_directory> <destination_zipfile>",
-    //         args[0]
-    //     );
-    //     return 1;
-    // }
-
     let args = Args::parse();
     let src_dir = &args.source_directory;
     let dst_file = &args.destination_zipfile;
-    let method: Option<zip::CompressionMethod> = match args.compression_method {
-        CompressionMethod::MethodStored => Some(zip::CompressionMethod::Stored),
+    let method = match args.compression_method {
+        CompressionMethod::MethodStored => zip::CompressionMethod::Stored,
         CompressionMethod::MethodDeflated => {
             #[cfg(not(feature = "deflate"))]
-            println!("The `deflate` feature is not enabled");
-            None;
+            {
+                println!("The `deflate` feature is not enabled");
+                return 1;
+            }
             #[cfg(feature = "deflate")]
-            Some(zip::CompressionMethod::Deflated)
+            zip::CompressionMethod::Deflated
         },
         CompressionMethod::MethodDeflatedMiniz => {
             #[cfg(not(feature = "deflate-miniz"))]
-            println!("The `deflate-miniz` feature is not enabled");
-            None;
+            {
+                println!("The `deflate-miniz` feature is not enabled");
+                return 1;
+            }
             #[cfg(feature = "deflate-miniz")]
-            Some(zip::CompressionMethod::Deflated)
+            zip::CompressionMethod::Deflated
         },
         CompressionMethod::MethodDeflatedZlib => {
             #[cfg(not(feature = "deflate-zlib"))]
-            println!("The `deflate-zlib` feature is not enabled");
-            None;
+            {
+                println!("The `deflate-zlib` feature is not enabled");
+                return 1;
+            }
             #[cfg(feature = "deflate-zlib")]
-            Some(zip::CompressionMethod::Deflated)
+            zip::CompressionMethod::Deflated
         },
         CompressionMethod::MethodBzip2 => {
             #[cfg(not(feature = "bzip2"))]
-            println!("The `bzip2` feature is not enabled");
-            None;
+            {
+                println!("The `bzip2` feature is not enabled");
+                return 1;
+            }
             #[cfg(feature = "bzip2")]
-            Some(zip::CompressionMethod::Bzip2)
+            zip::CompressionMethod::Bzip2
         },
         CompressionMethod::MethodZstd => {
             #[cfg(not(feature = "zstd"))]
-            println!("The `zstd` feature is not enabled");
-            None;
+            {
+                println!("The `zstd` feature is not enabled");
+                return 1;
+            }
             #[cfg(feature = "zstd")]
-            Some(zip::CompressionMethod::Zstd)
+            zip::CompressionMethod::Zstd
         }
     };
-    // for &method in [METHOD_STORED, METHOD_DEFLATED, METHOD_BZIP2, METHOD_ZSTD].iter() {
-    // if method.is_none() {
-    //     continue;
-    // }
     match doit(src_dir, dst_file, method) {
         Ok(_) => println!("done: {src_dir} written to {dst_file}"),
         Err(e) => println!("Error: {e:?}"),
     }
-    //}
 
     0
 }

--- a/examples/write_dir.rs
+++ b/examples/write_dir.rs
@@ -6,16 +6,16 @@ use zip::result::ZipError;
 use zip::write::FileOptions;
 
 use std::fs::File;
-use std::path::Path;
+use std::path::{PathBuf, Path};
 use walkdir::{DirEntry, WalkDir};
 
 #[derive(Parser)]
 #[command(about, long_about = None)]
 struct Args {
     // Source directory
-    source_directory: String,
+    source: PathBuf,
     // Destination zipfile 
-    destination_zipfile: String,
+    destination: PathBuf,
     // Compression method 
     #[arg(value_enum)]
     compression_method: CompressionMethod,
@@ -37,8 +37,8 @@ fn main() {
 
 fn real_main() -> i32 {
     let args = Args::parse();
-    let src_dir = &args.source_directory;
-    let dst_file = &args.destination_zipfile;
+    let src_dir = &args.source;
+    let dst_file = &args.destination;
     let method = match args.compression_method {
         CompressionMethod::MethodStored => zip::CompressionMethod::Stored,
         CompressionMethod::MethodDeflated => {
@@ -88,7 +88,7 @@ fn real_main() -> i32 {
         }
     };
     match doit(src_dir, dst_file, method) {
-        Ok(_) => println!("done: {src_dir} written to {dst_file}"),
+        Ok(_) => println!("done: {:?} written to {:?}", src_dir, dst_file),
         Err(e) => println!("Error: {e:?}"),
     }
 
@@ -97,7 +97,7 @@ fn real_main() -> i32 {
 
 fn zip_dir<T>(
     it: &mut dyn Iterator<Item = DirEntry>,
-    prefix: &str,
+    prefix: &Path,
     writer: T,
     method: zip::CompressionMethod,
 ) -> zip::result::ZipResult<()>
@@ -138,8 +138,8 @@ where
 }
 
 fn doit(
-    src_dir: &str,
-    dst_file: &str,
+    src_dir: &Path,
+    dst_file: &Path,
     method: zip::CompressionMethod,
 ) -> zip::result::ZipResult<()> {
     if !Path::new(src_dir).is_dir() {


### PR DESCRIPTION
In the write_dir example, the compression methods are iterated over in a loop and the resulting output zip file is repeatedly overwritten. Since ZStd is the last compression method in the loop, the output zip file is compressed using ZStd. 

This change updates the write_dir example to use clap and adds the compression method as an argument. Deflated-Miniz and Deflated-Zlib are broken out as separate methods based on the specified feature. If the feature needed for the compression method is not specified, we exit from main with an error. 