### PR TITLE
Add rs versions of bzip and zstd in order to pass static compiles

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ rust-version = "1.59.0"
 [dependencies]
 aes = { version = "0.8.2", optional = true }
 byteorder = "1.4.3"
-bzip2 = { version = "0.4.3", optional = true }
+bzip2-rs = { version = "0.1.2", optional = true }
 constant_time_eq = { version = "0.1.5", optional = true }
 crc32fast = "1.3.2"
 flate2 = { version = "1.0.23", default-features = false, optional = true }
@@ -22,7 +22,7 @@ hmac = { version = "0.12.1", optional = true, features = ["reset"] }
 pbkdf2 = {version = "0.11.0", optional = true }
 sha1 = {version = "0.10.1", optional = true }
 time = { version = "0.3.7", optional = true, default-features = false, features = ["std"] }
-zstd = { version = "0.11.2", optional = true }
+zstud-sys = { version = "0.1.3", optional = true }
 
 [target.'cfg(any(all(target_arch = "arm", target_pointer_width = "32"), target_arch = "mips", target_arch = "powerpc"))'.dependencies]
 crossbeam-utils = "0.8.8"
@@ -39,7 +39,7 @@ deflate = ["flate2/rust_backend"]
 deflate-miniz = ["flate2/default"]
 deflate-zlib = ["flate2/zlib"]
 unreserved = []
-default = ["aes-crypto", "bzip2", "deflate", "time", "zstd"]
+default = ["aes-crypto", "bzip2-rs", "deflate", "time", "zstud-sys"]
 
 [[bench]]
 name = "read_entry"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ hmac = { version = "0.12.1", optional = true, features = ["reset"] }
 pbkdf2 = {version = "0.11.0", optional = true }
 sha1 = {version = "0.10.1", optional = true }
 time = { version = "0.3.7", optional = true, default-features = false, features = ["std"] }
-zstud-sys = { version = "0.1.3", optional = true }
+zstd = { version = "0.11.2", default-features = false, optional = true }
 
 [target.'cfg(any(all(target_arch = "arm", target_pointer_width = "32"), target_arch = "mips", target_arch = "powerpc"))'.dependencies]
 crossbeam-utils = "0.8.8"
@@ -39,7 +39,7 @@ deflate = ["flate2/rust_backend"]
 deflate-miniz = ["flate2/default"]
 deflate-zlib = ["flate2/zlib"]
 unreserved = []
-default = ["aes-crypto", "bzip2-rs", "deflate", "time", "zstud-sys"]
+default = ["aes-crypto", "bzip2-rs", "deflate", "time", "zstd"]
 
 [[bench]]
 name = "read_entry"


### PR DESCRIPTION
Bzip-sys and Zstd-sys are the only two packages that require dynamic linking to system libs.
In order to pass a static compile (for use in containers), I recommend using a pure Rust impl of these compression algorithms.
Zstud seems to be using ffi functions, but it does produce a static lib. It does use system libs for compiling, which should be fine.