### PR TITLE
do not panic in Drop when stream is in an error state

### DIFF
--- a/src/read.rs
+++ b/src/read.rs
@@ -1004,8 +1004,10 @@ impl<'a> Drop for ZipFile<'a> {
                 match reader.read(&mut buffer) {
                     Ok(0) => break,
                     Ok(_) => (),
-                    Err(e) => {
-                        panic!("Could not consume all of the output of the current ZipFile: {e:?}")
+                    Err(_) => {
+                        // silently ignore this error - we're just trying to exhaust the reader
+                        // any further uses of the reader will return an error in a more appropriate context
+                        break;
                     }
                 }
             }


### PR DESCRIPTION
fixes #432 

This causes a panic for us when a stream errors (we pass in a reqwest stream): https://github.com/prefix-dev/pixi/issues/799