### PR TITLE
Add support for extended timestamps

### DIFF
--- a/src/cp437.rs
+++ b/src/cp437.rs
@@ -187,6 +187,7 @@ mod test {
     }
 
     #[test]
+    #[allow(invalid_from_utf8)]
     fn example_slice() {
         use super::FromCp437;
         let data = b"Cura\x87ao";

--- a/src/extra_fields/extended_timestamp.rs
+++ b/src/extra_fields/extended_timestamp.rs
@@ -1,0 +1,55 @@
+use std::marker::PhantomData;
+
+use super::{CentralHeaderVersion, ExtraFieldVersion, LocalHeaderVersion};
+
+pub struct ExtendedTimestamp<V: ExtraFieldVersion> {
+    flags: u8,
+    mod_time: u32,
+    ac_time: Option<u32>,
+    cr_time: Option<u32>,
+    _version: PhantomData<V>,
+}
+
+impl<V> ExtendedTimestamp<V> where V: ExtraFieldVersion {
+    pub fn flags(&self) -> u8 {
+        self.flags
+    }
+
+    pub fn mod_time(&self) -> u32 {
+        self.mod_time
+    }
+}
+
+impl ExtendedTimestamp<CentralHeaderVersion> {
+    pub fn new_central(flags: u8, mod_time: u32) -> Self {
+        Self {
+            flags,
+            mod_time,
+            ac_time: None,
+            cr_time: None,
+            _version: PhantomData
+        }
+    }
+}
+
+
+impl ExtendedTimestamp<LocalHeaderVersion> {
+    pub fn new_local(flags: u8, mod_time: u32, ac_time: u32, cr_time: u32) -> Self {
+        Self {
+            flags,
+            mod_time,
+            ac_time: Some(ac_time),
+            cr_time: Some(cr_time),
+            _version: PhantomData
+        }
+    }
+
+    pub fn ac_time(&self) -> u32 {
+        self.ac_time.unwrap()
+    }
+
+
+    pub fn cr_time(&self) -> u32 {
+        self.cr_time.unwrap()
+    }
+}

--- a/src/extra_fields/mod.rs
+++ b/src/extra_fields/mod.rs
@@ -1,5 +1,16 @@
+//! types for extra fields
+
+/// marker trait to denote the place where this extra field has been stored
 pub trait ExtraFieldVersion {}
+
+/// use this to mark extra fields specified in a local header
+
+#[derive(Debug, Clone)]
 pub struct LocalHeaderVersion;
+
+/// use this to mark extra fields specified in the central header
+
+#[derive(Debug, Clone)]
 pub struct CentralHeaderVersion;
 
 impl ExtraFieldVersion for LocalHeaderVersion {}
@@ -8,3 +19,11 @@ impl ExtraFieldVersion for CentralHeaderVersion {}
 mod extended_timestamp;
 
 pub use extended_timestamp::*;
+
+/// contains one extra field
+#[derive(Debug, Clone)]
+pub enum ExtraField {
+
+    /// extended timestamp, as described in <https://libzip.org/specifications/extrafld.txt>
+    ExtendedTimestamp(ExtendedTimestamp)
+}

--- a/src/extra_fields/mod.rs
+++ b/src/extra_fields/mod.rs
@@ -1,0 +1,10 @@
+pub trait ExtraFieldVersion {}
+pub struct LocalHeaderVersion;
+pub struct CentralHeaderVersion;
+
+impl ExtraFieldVersion for LocalHeaderVersion {}
+impl ExtraFieldVersion for CentralHeaderVersion {}
+
+mod extended_timestamp;
+
+pub use extended_timestamp::*;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -42,6 +42,7 @@ mod spec;
 mod types;
 pub mod write;
 mod zipcrypto;
+pub mod extra_fields;
 
 /// Unstable APIs
 ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,6 +43,7 @@ mod types;
 pub mod write;
 mod zipcrypto;
 pub mod extra_fields;
+pub use extra_fields::ExtraField;
 
 /// Unstable APIs
 ///

--- a/src/read.rs
+++ b/src/read.rs
@@ -985,6 +985,11 @@ impl<'a> ZipFile<'a> {
     pub fn central_header_start(&self) -> u64 {
         self.data.central_header_start
     }
+    
+    /// iterate through all extra fields
+    pub fn extra_data_fields(&self) -> impl Iterator<Item=&ExtraField> {
+        self.data.extra_fields.iter()
+    }
 }
 
 impl<'a> Read for ZipFile<'a> {

--- a/src/read.rs
+++ b/src/read.rs
@@ -990,7 +990,7 @@ impl<'a> Drop for ZipFile<'a> {
             // Get the inner `Take` reader so all decryption, decompression and CRC calculation is skipped.
             let mut reader: std::io::Take<&mut dyn std::io::Read> = match &mut self.reader {
                 ZipFileReader::NoReader => {
-                    let innerreader = ::std::mem::replace(&mut self.crypto_reader, None);
+                    let innerreader = self.crypto_reader.take();
                     innerreader.expect("Invalid reader state").into_inner()
                 }
                 reader => {

--- a/src/read.rs
+++ b/src/read.rs
@@ -935,8 +935,7 @@ impl<'a> ZipFile<'a> {
     pub fn is_dir(&self) -> bool {
         self.name()
             .chars()
-            .rev()
-            .next()
+            .next_back()
             .map_or(false, |c| c == '/' || c == '\\')
     }
 

--- a/src/read.rs
+++ b/src/read.rs
@@ -812,6 +812,9 @@ fn parse_extra_field(file: &mut ZipFileData) -> ZipResult<()> {
                 file.extra_fields.push(ExtraField::ExtendedTimestamp(
                     ExtendedTimestamp::try_from_reader(&mut reader, len)?,
                 ));
+
+                // the reader for ExtendedTimestamp consumes `len` bytes
+                len_left = 0;
             }
             _ => {
                 // Other fields are ignored

--- a/src/read/stream.rs
+++ b/src/read/stream.rs
@@ -184,8 +184,7 @@ impl ZipStreamFileMetadata {
     pub fn is_dir(&self) -> bool {
         self.name()
             .chars()
-            .rev()
-            .next()
+            .next_back()
             .map_or(false, |c| c == '/' || c == '\\')
     }
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -49,6 +49,7 @@ mod atomic {
     }
 }
 
+use crate::extra_fields::ExtraField;
 #[cfg(feature = "time")]
 use crate::result::DateTimeRangeError;
 #[cfg(feature = "time")]
@@ -350,6 +351,9 @@ pub struct ZipFileData {
     pub large_file: bool,
     /// AES mode if applicable
     pub aes_mode: Option<(AesMode, AesVendorVersion)>,
+
+    /// extra fields, see <https://libzip.org/specifications/extrafld.txt>
+    pub extra_fields: Vec<ExtraField>,
 }
 
 impl ZipFileData {
@@ -508,6 +512,7 @@ mod test {
             external_attributes: 0,
             large_file: false,
             aes_mode: None,
+            extra_fields: Vec::new(),
         };
         assert_eq!(
             data.file_name_sanitized(),

--- a/src/write.rs
+++ b/src/write.rs
@@ -411,7 +411,7 @@ impl<W: Write + io::Seek> ZipWriter<W> {
         }
         if let Some(keys) = options.encrypt_with {
             let mut zipwriter = crate::zipcrypto::ZipCryptoWriter { writer: core::mem::replace(&mut self.inner, GenericZipWriter::Closed).unwrap(), buffer: vec![], keys };
-            let mut crypto_header = [0u8; 12];
+            let crypto_header = [0u8; 12];
 
             zipwriter.write_all(&crypto_header)?;
             self.inner = GenericZipWriter::Storer(MaybeEncrypted::Encrypted(zipwriter));

--- a/src/write.rs
+++ b/src/write.rs
@@ -397,6 +397,7 @@ impl<W: Write + io::Seek> ZipWriter<W> {
                 external_attributes: permissions << 16,
                 large_file: options.large_file,
                 aes_mode: None,
+                extra_fields: Vec::new(),
             };
             write_local_file_header(writer, &file)?;
 


### PR DESCRIPTION
Zip files may contain (and mostly do) extended data, such as extended timestamps. This PR adds structs for reading extended data, and firstly the extended timestamp fields.

This PR is required to solve dfir-dd/dfir-toolkit#27