### PR TITLE
Remove unnecessary "mut"

### DIFF
--- a/src/aes_ctr.rs
+++ b/src/aes_ctr.rs
@@ -5,7 +5,6 @@
 //! See [AesCtrZipKeyStream] for more information.
 
 use aes::cipher::generic_array::GenericArray;
-// use aes::{BlockEncrypt, NewBlockCipher};
 use aes::cipher::{BlockEncrypt, KeyInit};
 use byteorder::WriteBytesExt;
 use std::{any, fmt};
@@ -28,7 +27,7 @@ pub trait AesKind {
     /// Key type.
     type Key: AsRef<[u8]>;
     /// Cipher used to decrypt.
-    type Cipher;
+    type Cipher: KeyInit;
 }
 
 impl AesKind for Aes128 {
@@ -155,21 +154,21 @@ mod tests {
 
     /// Checks whether `crypt_in_place` produces the correct plaintext after one use and yields the
     /// cipertext again after applying it again.
-    fn roundtrip<Aes>(key: &[u8], ciphertext: &mut [u8], expected_plaintext: &[u8])
+    fn roundtrip<Aes>(key: &[u8], ciphertext: &[u8], expected_plaintext: &[u8])
     where
         Aes: AesKind,
         Aes::Cipher: KeyInit + BlockEncrypt,
     {
         let mut key_stream = AesCtrZipKeyStream::<Aes>::new(key);
 
-        let mut plaintext: Vec<u8> = ciphertext.to_vec();
-        key_stream.crypt_in_place(plaintext.as_mut_slice());
-        assert_eq!(plaintext, expected_plaintext.to_vec());
+        let mut plaintext = ciphertext.to_vec().into_boxed_slice();
+        key_stream.crypt_in_place(&mut plaintext);
+        assert_eq!(*plaintext, *expected_plaintext);
 
         // Round-tripping should yield the ciphertext again.
         let mut key_stream = AesCtrZipKeyStream::<Aes>::new(key);
         key_stream.crypt_in_place(&mut plaintext);
-        assert_eq!(plaintext, ciphertext.to_vec());
+        assert_eq!(*plaintext, *ciphertext);
     }
 
     #[test]
@@ -183,7 +182,7 @@ mod tests {
     // `7z a -phelloworld -mem=AES256 -mx=0 aes256_40byte.zip 40byte_data.txt`
     #[test]
     fn crypt_aes_256_0_byte() {
-        let mut ciphertext = [];
+        let ciphertext = [];
         let expected_plaintext = &[];
         let key = [
             0x0b, 0xec, 0x2e, 0xf2, 0x46, 0xf0, 0x7e, 0x35, 0x16, 0x54, 0xe0, 0x98, 0x10, 0xb3,
@@ -196,7 +195,7 @@ mod tests {
 
     #[test]
     fn crypt_aes_128_5_byte() {
-        let mut ciphertext = [0x98, 0xa9, 0x8c, 0x26, 0x0e];
+        let ciphertext = [0x98, 0xa9, 0x8c, 0x26, 0x0e];
         let expected_plaintext = b"asdf\n";
         let key = [
             0xe0, 0x25, 0x7b, 0x57, 0x97, 0x6a, 0xa4, 0x23, 0xab, 0x94, 0xaa, 0x44, 0xfd, 0x47,
@@ -208,7 +207,7 @@ mod tests {
 
     #[test]
     fn crypt_aes_192_5_byte() {
-        let mut ciphertext = [0x36, 0x55, 0x5c, 0x61, 0x3c];
+        let ciphertext = [0x36, 0x55, 0x5c, 0x61, 0x3c];
         let expected_plaintext = b"asdf\n";
         let key = [
             0xe4, 0x4a, 0x88, 0x52, 0x8f, 0xf7, 0x0b, 0x81, 0x7b, 0x75, 0xf1, 0x74, 0x21, 0x37,
@@ -220,7 +219,7 @@ mod tests {
 
     #[test]
     fn crypt_aes_256_5_byte() {
-        let mut ciphertext = [0xc2, 0x47, 0xc0, 0xdc, 0x56];
+        let ciphertext = [0xc2, 0x47, 0xc0, 0xdc, 0x56];
         let expected_plaintext = b"asdf\n";
         let key = [
             0x79, 0x5e, 0x17, 0xf2, 0xc6, 0x3d, 0x28, 0x9b, 0x4b, 0x4b, 0xbb, 0xa9, 0xba, 0xc9,
@@ -233,7 +232,7 @@ mod tests {
 
     #[test]
     fn crypt_aes_128_40_byte() {
-        let mut ciphertext = [
+        let ciphertext = [
             0xcf, 0x72, 0x6b, 0xa1, 0xb2, 0x0f, 0xdf, 0xaa, 0x10, 0xad, 0x9c, 0x7f, 0x6d, 0x1c,
             0x8d, 0xb5, 0x16, 0x7e, 0xbb, 0x11, 0x69, 0x52, 0x8c, 0x89, 0x80, 0x32, 0xaa, 0x76,
             0xa6, 0x18, 0x31, 0x98, 0xee, 0xdd, 0x22, 0x68, 0xb7, 0xe6, 0x77, 0xd2,
@@ -249,7 +248,7 @@ mod tests {
 
     #[test]
     fn crypt_aes_192_40_byte() {
-        let mut ciphertext = [
+        let ciphertext = [
             0xa6, 0xfc, 0x52, 0x79, 0x2c, 0x6c, 0xfe, 0x68, 0xb1, 0xa8, 0xb3, 0x07, 0x52, 0x8b,
             0x82, 0xa6, 0x87, 0x9c, 0x72, 0x42, 0x3a, 0xf8, 0xc6, 0xa9, 0xc9, 0xfb, 0x61, 0x19,
             0x37, 0xb9, 0x56, 0x62, 0xf4, 0xfc, 0x5e, 0x7a, 0xdd, 0x55, 0x0a, 0x48,
@@ -265,7 +264,7 @@ mod tests {
 
     #[test]
     fn crypt_aes_256_40_byte() {
-        let mut ciphertext = [
+        let ciphertext = [
             0xa9, 0x99, 0xbd, 0xea, 0x82, 0x9b, 0x8f, 0x2f, 0xb7, 0x52, 0x2f, 0x6b, 0xd8, 0xf6,
             0xab, 0x0e, 0x24, 0x51, 0x9e, 0x18, 0x0f, 0xc0, 0x8f, 0x54, 0x15, 0x80, 0xae, 0xbc,
             0xa0, 0x5c, 0x8a, 0x11, 0x8d, 0x14, 0x7e, 0xc5, 0xb4, 0xae, 0xd3, 0x37,


### PR DESCRIPTION
roundtrip() takes a &mut, but only uses this argument non-mutably.